### PR TITLE
add avro support for RecordValue object

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -6,6 +6,7 @@
 name: Scala CI - Run Tests
 
 on:
+  workflow_dispatch:
   push:
     branches: [ "main" ]
   pull_request:

--- a/data-quality-profiler/build.sbt
+++ b/data-quality-profiler/build.sbt
@@ -63,6 +63,9 @@ libraryDependencies += "com.itextpdf" % "html2pdf" % "4.0.3"
 // https://mvnrepository.com/artifact/com.github.spullara.mustache.java/compiler
 libraryDependencies += "com.github.spullara.mustache.java" % "compiler" % "0.9.10"
 
+//avro support
+libraryDependencies += "org.apache.avro" % "avro" % "1.11.2"
+
 
 Test / parallelExecution := true
 

--- a/data-quality-profiler/build.sbt
+++ b/data-quality-profiler/build.sbt
@@ -64,7 +64,7 @@ libraryDependencies += "com.itextpdf" % "html2pdf" % "4.0.3"
 libraryDependencies += "com.github.spullara.mustache.java" % "compiler" % "0.9.10"
 
 //avro support
-libraryDependencies += "org.apache.avro" % "avro" % "1.11.2"
+libraryDependencies += "org.apache.avro" % "avro" % "1.11.1"
 
 
 Test / parallelExecution := true

--- a/data-quality-profiler/src/main/scala/uk/gov/ipt/das/dataprofiler/value/RecordValue.scala
+++ b/data-quality-profiler/src/main/scala/uk/gov/ipt/das/dataprofiler/value/RecordValue.scala
@@ -86,6 +86,7 @@ object RecordValue {
         case v: java.util.LinkedHashMap[String, Any] => ProfilableRecord.fromLinkedHashMap(linkedHashMap = v)
         case v: java.math.BigDecimal => DoubleValue(v.doubleValue()) // TODO do better, write tests against this
         case v: java.util.ArrayList[_] => ArrayValue(v.asScala.map{ RecordValue.fromAny })
+        case v: org.apache.avro.util.Utf8 => StringValue(v.toString)
         case foo =>
           throw new Exception(s"Unknown primtive type of in RecordValue.fromPrimitive: $foo, class: ${foo.getClass}")
       }

--- a/data-quality-profiler/src/test/scala/uk/gov/ipt/das/dataprofiler/value/ValuesTests.scala
+++ b/data-quality-profiler/src/test/scala/uk/gov/ipt/das/dataprofiler/value/ValuesTests.scala
@@ -105,6 +105,11 @@ class ValuesTests extends AnyFunSpec {
 
     }
 
+    it("should return a string for a avro record value") {
+      val testValue = RecordValue.fromAny( new org.apache.avro.util.Utf8("foo"))
+      assertResult(testValue.asString)("foo")
+    }
+
   }
 
 }


### PR DESCRIPTION
This ensure that if we are working with avro data e.g avro strings(org.apache.avro.util.Utf8) we can decode them properly.